### PR TITLE
Fix: Weeknotes - 2022, Week 2 - links were broken

### DIFF
--- a/src/posts/weeknotes-2022-2.md
+++ b/src/posts/weeknotes-2022-2.md
@@ -11,14 +11,14 @@ featuredImage: /img/alien-sketch-480w.webp
 ---
 - It was a great feeling to install one of our “Core Blocks” via Composer and just having it work. It reminded me that we have actually been making progress towards the “two-week build”.
 - An otherwise disjointed week at work, but I feel like we’re getting some direction on how we are going to approach Keyboard navigation and Screen reader testing.
-- I had a go at [conventional commits]([https://www.conventionalcommits.org/en/v1.0.0/](https://www.conventionalcommits.org/en/v1.0.0/)) this week. They’re good. To be honest I had no idea a commit message could be more than one line and a certain number of characters!
+- I had a go at [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) this week. They’re good. To be honest I had no idea a commit message could be more than one line and a certain number of characters!
 - Also had a play with WordPress 5.9 RC2: Full Site Editing is a vast improvement on 3 months ago, but I wish they’d work out what they’re doing with Navigation menus - I know they’re a Post Type, but why do they have their own editing page when all you can change is the title?
 - I was introduced to the OODA loop (*observe–orient–decide–act).* This is something I should come back to - I want to explore its relationship to the PDCA and other frameworks that seem to have become more popular in business than the warfare based OODA.
 - Made a cheese and kimchi (kim-cheese) toastie for the first time - I think it worked...
 - I’ve been calling Kae Tempest “Kate” for years, and nobody noticed because of my glottal stop (glo’al stop).
 - This week I also learned:
     - Weighted lunges still give me sore adductors
-    - The origins of the term “Secret Squirrel” pre-date the cartoon. Here’s one amusing yet unconfirmed theory about its origin: [[https://www.sandboxx.us/blog/spy-culture-what-is-a-secret-squirrel/](https://www.sandboxx.us/blog/spy-culture-what-is-a-secret-squirrel/)]([https://www.sandboxx.us/blog/spy-culture-what-is-a-secret-squirrel/](https://www.sandboxx.us/blog/spy-culture-what-is-a-secret-squirrel/))
+    - The origins of the term “Secret Squirrel” pre-date the cartoon. Here’s one amusing yet unconfirmed theory about its origin: [https://www.sandboxx.us/blog/spy-culture-what-is-a-secret-squirrel/](https://www.sandboxx.us/blog/spy-culture-what-is-a-secret-squirrel/)
     - Empty `alt` attributes are preferred to `role="presentation"`
 - We’ve started a Sketch Club at work - this week’s word was “Alien”. Unusually I used brushes a lot on it and found them a lot more versatile for sketching than I ever thought.
 


### PR DESCRIPTION
Links had been auto converted to markdown when pasted in to editor, even though they were already written in markdown